### PR TITLE
Updated logged name from Asseble to Assemble

### DIFF
--- a/src/assemble-task.js
+++ b/src/assemble-task.js
@@ -4,7 +4,7 @@ const extname = require('gulp-extname');
 const plumber = require('gulp-plumber');
 
 function handleAssemble(params) {
-  console.log(chalk.black.bold('Asseble.io - Starts'));
+  console.log(chalk.black.bold('Assemble.io - Starts'));
 
   const {
     queries: { baseLayout, partialsLayout, basePages, partialsData, helpers },
@@ -49,7 +49,7 @@ function handleAssemble(params) {
     .pipe(app.renderFile())
     .pipe(app.dest(outputPath));
 
-  console.log(chalk.black.bold('Asseble.io - Ends'));
+  console.log(chalk.black.bold('Assemble.io - Ends'));
 }
 
 module.exports = {


### PR DESCRIPTION
Small fix on the name which is printed during the webpack execution:
```
Asseble.io - Starts
[...]
Asseble.io - Ends
```
becomes
```
Assemble.io - Starts
[...]
Assemble.io - Ends
```